### PR TITLE
[semver:patch] process error json on failure

### DIFF
--- a/src/scripts/package-build.sh
+++ b/src/scripts/package-build.sh
@@ -53,7 +53,7 @@ build_package() {
         params+=( --target-dev-hub "$PARAM_DEV_HUB")
     fi
     echo "sf package version create ${params[*]}"
-    sf_package_version_create "${params[@]}" | tee package_version_create_result.json
+    sf_package_version_create "${params[@]}" | tee package_version_create_result.json || true
 }
 
 process_build_result() {

--- a/src/scripts/package-install.sh
+++ b/src/scripts/package-install.sh
@@ -84,7 +84,7 @@ install_package() {
         params+=( --installation-key "${!PARAM_INSTALLATION_KEY}")
     fi
     echo "sf package install ${params[*]}"
-    install_package_with_params "${params[@]}" | tee package_version_install_result.json
+    install_package_with_params "${params[@]}" | tee package_version_install_result.json || true
 }
 
 process_install_result() {


### PR DESCRIPTION
Bats tests run differently than pipeline (`#!/bin/bash -eo pipefail`). This is why piped command fails in pipeline but not in the bats tests. With that fix it won't fail anymore in the pipeline. The error json can then be processed by the script, as expected. 